### PR TITLE
fix: restart countdown tick when card reconnects to DOM

### DIFF
--- a/src/components/TimeFlowCard.ts
+++ b/src/components/TimeFlowCard.ts
@@ -578,6 +578,9 @@ export class TimeFlowCard extends LitElement {
     super.connectedCallback();
     // Connect template service for WebSocket subscriptions
     this.templateService.connect();
+    if (this._initialized) {
+      this._startCountdownUpdates();
+    }
   }
 
   // Cleanup on disconnect - unsubscribe from all WebSocket connections


### PR DESCRIPTION
Fixes the countdown not ticking after the card is reattached to the DOM (eg. switching dashboard tabs). connectedCallback() never restarted the 1 second update interval, only firstUpdated() did, which only runs once per element. Now connectedCallback() restarts it too when needed.