### PR TITLE
fix: don't bake auto computed compact_format into config in editor

### DIFF
--- a/src/components/TimeFlowCardEditor.ts
+++ b/src/components/TimeFlowCardEditor.ts
@@ -148,8 +148,15 @@ export class TimeFlowCardEditor extends LitElement {
 
     private _formChanged(ev: CustomEvent) {
         const value = ev.detail?.value || {};
+        const wasExplicit = this._config?.compact_format !== undefined;
+        const previousDisplayedCompactFormat = this._getEffectiveCompactFormat();
         // Merge with existing config and keep the card type
         const newConfig = { ...(this._config || {}), ...value, type: this._config?.type || 'custom:timeflow-card' } as CardConfig;
+
+        if (!wasExplicit && value.compact_format === previousDisplayedCompactFormat) {
+            delete newConfig.compact_format;
+        }
+
         this._config = newConfig;
         this._fireConfigChanged(newConfig);
     }


### PR DESCRIPTION
Fixes the visual editor permanently locking compact_format to an explicit true/false the moment you edit any other field. It was saving the auto computed display value instead of leaving it as "auto" when the user never touched that checkbox.